### PR TITLE
Fix polygit base URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<base href="https://polygit.org/simple-timeline+samie+master/components/">
+<base href="https://polygit.org/polymer+^1.0.0/simple-timeline+samie+:master/components/">
 
 <script src="webcomponentsjs/webcomponents-lite.js"></script>
 


### PR DESCRIPTION
There were 2 issues in the polygit base URL:

1. Polymer wasn't included
2. simple-timeline component was included with incorrect syntax (without colon)